### PR TITLE
Add global YAML configuration module

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1188,6 +1188,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hello-tauri"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
+ "serde",
+ "serde_yaml",
  "tauri",
  "tauri-build",
 ]
@@ -2543,6 +2546,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa 1.0.15",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3294,6 +3310,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,6 +5,9 @@ edition = "2021"
 
 [dependencies]
 tauri = { version = "1", features = [] }
+once_cell = "1"
+serde = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
 
 [build-dependencies]
 tauri-build = { version = "1", features = [] }

--- a/src-tauri/config.yaml
+++ b/src-tauri/config.yaml
@@ -1,0 +1,2 @@
+# Configuration file for the ntx-pm application
+# Values can be modified at runtime via the configuration module.

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,0 +1,77 @@
+use once_cell::sync::Lazy;
+use serde::{de::DeserializeOwned, Serialize};
+use serde_yaml::{self, Value};
+use std::{collections::HashMap, fs, io, path::PathBuf, sync::RwLock};
+
+/// Inner representation of the application configuration.
+#[derive(Default)]
+struct Config {
+    path: PathBuf,
+    data: HashMap<String, Value>,
+}
+
+impl Config {
+    fn load(path: PathBuf) -> Self {
+        let data = if path.exists() {
+            fs::read_to_string(&path)
+                .ok()
+                .and_then(|contents| serde_yaml::from_str(&contents).ok())
+                .unwrap_or_default()
+        } else {
+            HashMap::new()
+        };
+        Self { path, data }
+    }
+
+    fn save(&self) -> io::Result<()> {
+        let contents = serde_yaml::to_string(&self.data)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        fs::write(&self.path, contents)
+    }
+
+    fn get<T: DeserializeOwned>(&self, key: &str) -> Option<T> {
+        self.data
+            .get(key)
+            .and_then(|v| serde_yaml::from_value(v.clone()).ok())
+    }
+
+    fn set<T: Serialize>(&mut self, key: &str, value: T) -> io::Result<()> {
+        let yaml_value =
+            serde_yaml::to_value(value).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+        self.data.insert(key.to_string(), yaml_value);
+        self.save()
+    }
+}
+
+static CONFIG: Lazy<RwLock<Config>> = Lazy::new(|| {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("config.yaml");
+    RwLock::new(Config::load(path))
+});
+
+/// Retrieve a single value from the configuration.
+pub fn get_value<T: DeserializeOwned>(key: &str) -> Option<T> {
+    CONFIG.read().ok().and_then(|cfg| cfg.get(key))
+}
+
+/// Store a single value in the configuration.
+pub fn set_value<T: Serialize>(key: &str, value: T) -> io::Result<()> {
+    CONFIG
+        .write()
+        .map_err(|_| io::Error::new(io::ErrorKind::Other, "Lock poisoned"))?
+        .set(key, value)
+}
+
+/// Retrieve a list of values from the configuration.
+pub fn get_list<T: DeserializeOwned>(key: &str) -> Option<Vec<T>> {
+    get_value(key)
+}
+
+/// Store a list of values in the configuration.
+pub fn set_list<T: Serialize>(key: &str, list: Vec<T>) -> io::Result<()> {
+    set_value(key, list)
+}
+
+/// Ensure that the configuration file is initialized.
+pub fn init() {
+    Lazy::force(&CONFIG);
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,6 +1,11 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod config;
+
 fn main() {
+    // Initialize configuration at startup so it is available application-wide.
+    config::init();
+
     tauri::Builder::default()
         .run(tauri::generate_context!())
         .expect("error while running tauri application");


### PR DESCRIPTION
## Summary
- introduce a YAML-based configuration service backed by a global singleton
- expose helper methods for retrieving and storing single values or lists
- initialize config during startup

## Testing
- `cargo fmt --all -- --check`
- `cargo test` *(fails: javascriptcoregtk-4.0 library not found)*

------
https://chatgpt.com/codex/tasks/task_e_68953786c138833186ccc88b6b9ed0f8